### PR TITLE
feat: Thunderbird-CSV-Import mit Kontakt-Picker und Gruppenverwaltung

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         description: 'Neue Version (z.B. 1.2.0 — ohne "v")'
         required: true
         type: string
+      draft:
+        description: 'Als Draft-Release veröffentlichen'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -84,6 +89,7 @@ jobs:
         with:
           tag_name: "v${{ env.VERSION }}"
           name: "Kater v${{ env.VERSION }}"
+          draft: ${{ inputs.draft || false }}
           files: |
             Kater-${{ env.VERSION }}-x86_64.AppImage
             Kater-x86_64.AppImage

--- a/adressbuch/gui/app.py
+++ b/adressbuch/gui/app.py
@@ -9,9 +9,12 @@ from typing import Optional
 from .. import __version__
 from ..models.contact import Contact
 from ..storage.database import Database
+from ..storage.settings import Settings
 from ..storage.vcard import VCardParser, VCardExporter
+from ..storage.csv_import import ThunderbirdCsvParser
 from .utils import resolve_asset
 from .contact_form import ContactForm
+from .csv_import_dialog import CsvImportDialog
 from .qr_dialog import QRDialog
 
 
@@ -30,6 +33,8 @@ class AdressbuchApp(tk.Tk):
         self.focus_force()
 
         self.db = Database(db_path)
+        db_path = Path(db_path)
+        self.settings = Settings(db_path.parent / (db_path.stem + "_settings.json"))
         self._selected_uid: Optional[str] = None
 
         self._build_ui()
@@ -59,11 +64,21 @@ class AdressbuchApp(tk.Tk):
 
         tb_menu = tk.Menu(file_menu, tearoff=0)
         file_menu.add_cascade(label="Thunderbird / vCard", menu=tb_menu)
-        tb_menu.add_command(label="Importieren...", command=self._import_vcard)
+        tb_menu.add_command(label="vCard importieren...", command=self._import_vcard)
+        tb_menu.add_command(label="CSV importieren (Thunderbird)...", command=self._import_csv)
         tb_menu.add_separator()
         tb_menu.add_command(label="Aktuellen Kontakt exportieren...", command=self._export_vcard)
         tb_menu.add_command(label="Markierte Kontakte exportieren...", command=self._export_selected)
         tb_menu.add_command(label="Alle Kontakte exportieren...", command=self._export_all)
+
+        extras_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Extras", menu=extras_menu)
+        self._groups_var = tk.BooleanVar(value=self.settings.groups_enabled)
+        extras_menu.add_checkbutton(
+            label="Gruppen aktivieren",
+            variable=self._groups_var,
+            command=self._toggle_groups,
+        )
 
         file_menu.add_command(label="Als QR-Code anzeigen", command=self._show_qr, accelerator="Ctrl+Q")
         file_menu.add_separator()
@@ -289,6 +304,49 @@ class AdressbuchApp(tk.Tk):
         self._load_contacts(self._search_var.get().strip())
 
     # --- vCard Import/Export ---
+
+    def _import_csv(self):
+        path = filedialog.askopenfilename(
+            title="Thunderbird-CSV importieren",
+            filetypes=[("CSV Dateien", "*.csv"), ("Alle Dateien", "*.*")]
+        )
+        if not path:
+            return
+        parser = ThunderbirdCsvParser()
+        try:
+            contacts = parser.parse_file(path)
+        except Exception as e:
+            messagebox.showerror("Importfehler", str(e))
+            return
+        if not contacts:
+            messagebox.showinfo("CSV-Import", "Keine Kontakte in der Datei gefunden.")
+            return
+        filename = Path(path).stem
+        CsvImportDialog(
+            self, contacts, filename,
+            on_import=self._finish_csv_import,
+        )
+
+    def _finish_csv_import(self, contacts: list[Contact], group_name: str):
+        group_id: int | None = None
+        if group_name:
+            self.settings.groups_enabled = True
+            self._groups_var.set(True)
+            group_id = self.db.create_group(group_name)
+
+        for c in contacts:
+            self.db.save(c)
+            if group_id is not None:
+                self.db.add_contact_to_group(c.uid, group_id)
+
+        self._load_contacts(self._search_var.get().strip())
+        msg = f"{len(contacts)} Kontakt(e) importiert."
+        if group_name:
+            msg += f'\nGruppe "{group_name}" wurde angelegt.'
+        messagebox.showinfo("Import abgeschlossen", msg)
+
+    def _toggle_groups(self):
+        self.settings.groups_enabled = self._groups_var.get()
 
     def _import_vcard(self):
         path = filedialog.askopenfilename(

--- a/adressbuch/gui/csv_import_dialog.py
+++ b/adressbuch/gui/csv_import_dialog.py
@@ -1,0 +1,157 @@
+"""Vorschau-Dialog für den CSV-Import mit Kontaktauswahl."""
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Callable
+
+from ..models.contact import Contact
+
+
+class CsvImportDialog(tk.Toplevel):
+    """Zeigt importierte Kontakte zur Auswahl an, mit optionaler Gruppenzuweisung."""
+
+    _CHECKED   = "☑"
+    _UNCHECKED = "☐"
+
+    def __init__(
+        self,
+        parent: tk.Tk,
+        contacts: list[Contact],
+        filename: str,
+        on_import: Callable[[list[Contact], str], None],
+    ):
+        super().__init__(parent)
+        self.title(f"CSV-Import: {filename}")
+        self.resizable(True, True)
+        self.geometry("680x500")
+        self.grab_set()
+
+        self._contacts  = contacts
+        self._on_import = on_import
+        self._checked: dict[str, bool] = {}
+
+        self._build_ui()
+        self._populate()
+        self._update_count()
+        self.after(10, lambda: self._center(parent))
+
+    # --- UI-Aufbau ---
+
+    def _build_ui(self):
+        # Kopfzeile: Info + Alle/Keine
+        top = ttk.Frame(self, padding=(8, 6))
+        top.pack(fill="x")
+
+        self._info_label = ttk.Label(top, text="")
+        self._info_label.pack(side="left")
+
+        ttk.Button(top, text="Keine", command=self._select_none).pack(side="right", padx=(2, 0))
+        ttk.Button(top, text="Alle",  command=self._select_all).pack(side="right")
+
+        # Kontakttabelle
+        tree_frame = ttk.Frame(self)
+        tree_frame.pack(fill="both", expand=True, padx=8, pady=(0, 4))
+
+        self._tree = ttk.Treeview(
+            tree_frame,
+            columns=("check", "name", "email"),
+            show="headings",
+            selectmode="none",
+        )
+        self._tree.heading("check", text="")
+        self._tree.heading("name",  text="Name")
+        self._tree.heading("email", text="E-Mail")
+        self._tree.column("check", width=32,  minwidth=32,  stretch=False, anchor="center")
+        self._tree.column("name",  width=230, minwidth=120)
+        self._tree.column("email", width=280, minwidth=120)
+
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self._tree.yview)
+        self._tree.configure(yscrollcommand=vsb.set)
+        self._tree.pack(side="left", fill="both", expand=True)
+        vsb.pack(side="right", fill="y")
+
+        self._tree.bind("<Button-1>", self._on_click)
+
+        # Fußzeile: optionaler Gruppenname + Buttons
+        bottom = ttk.Frame(self, padding=(8, 6))
+        bottom.pack(fill="x")
+
+        self._group_var = tk.StringVar()
+        ttk.Label(bottom, text="Als Gruppe importieren (optional):").pack(side="left")
+        ttk.Entry(bottom, textvariable=self._group_var, width=22).pack(side="left", padx=(4, 16))
+
+        ttk.Button(bottom, text="Abbrechen",  command=self.destroy).pack(side="right", padx=(4, 0))
+        self._import_btn = ttk.Button(bottom, text="Importieren", command=self._do_import)
+        self._import_btn.pack(side="right")
+
+    # --- Daten ---
+
+    def _populate(self):
+        for c in self._contacts:
+            iid = self._tree.insert(
+                "", "end",
+                values=(self._CHECKED, c.get_display_name(), self._primary_email(c))
+            )
+            self._checked[iid] = True
+
+    @staticmethod
+    def _primary_email(c: Contact) -> str:
+        for e in c.emails:
+            if e.preferred:
+                return e.address
+        return c.emails[0].address if c.emails else ""
+
+    # --- Interaktion ---
+
+    def _on_click(self, event):
+        if self._tree.identify_region(event.x, event.y) != "cell":
+            return
+        iid = self._tree.identify_row(event.y)
+        if iid:
+            self._toggle(iid)
+
+    def _toggle(self, iid: str):
+        self._checked[iid] = not self._checked[iid]
+        vals = list(self._tree.item(iid, "values"))
+        vals[0] = self._CHECKED if self._checked[iid] else self._UNCHECKED
+        self._tree.item(iid, values=vals)
+        self._update_count()
+
+    def _select_all(self):
+        for iid in self._checked:
+            self._checked[iid] = True
+            vals = list(self._tree.item(iid, "values"))
+            vals[0] = self._CHECKED
+            self._tree.item(iid, values=vals)
+        self._update_count()
+
+    def _select_none(self):
+        for iid in self._checked:
+            self._checked[iid] = False
+            vals = list(self._tree.item(iid, "values"))
+            vals[0] = self._UNCHECKED
+            self._tree.item(iid, values=vals)
+        self._update_count()
+
+    def _update_count(self):
+        total    = len(self._checked)
+        selected = sum(1 for v in self._checked.values() if v)
+        self._info_label.config(text=f"{selected} von {total} Kontakten ausgewählt")
+        self._import_btn.config(state="normal" if selected > 0 else "disabled")
+
+    def _do_import(self):
+        iids = list(self._tree.get_children())
+        selected = [
+            self._contacts[i]
+            for i, iid in enumerate(iids)
+            if self._checked.get(iid, False)
+        ]
+        group_name = self._group_var.get().strip()
+        self.destroy()
+        self._on_import(selected, group_name)
+
+    def _center(self, parent: tk.Tk):
+        self.update_idletasks()
+        x = parent.winfo_x() + (parent.winfo_width()  - self.winfo_width())  // 2
+        y = parent.winfo_y() + (parent.winfo_height() - self.winfo_height()) // 2
+        self.geometry(f"+{x}+{y}")

--- a/adressbuch/storage/csv_import.py
+++ b/adressbuch/storage/csv_import.py
@@ -1,0 +1,110 @@
+"""Thunderbird-CSV-Import."""
+
+import csv
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+from ..models.contact import Contact, Address, Email, Phone, Url
+
+
+class ThunderbirdCsvParser:
+    """Parst Thunderbird-CSV-Exporte (Adressbuch → Exportieren als CSV)."""
+
+    _SIMPLE_FIELDS = {
+        "First Name":   "given_name",
+        "Last Name":    "family_name",
+        "Display Name": "display_name",
+        "Nickname":     "nickname",
+        "Job Title":    "title",
+        "Department":   "org_unit",
+        "Organization": "organization",
+        "Notes":        "note",
+    }
+
+    _PHONE_COLS = [
+        ("Work Phone",    ["work", "voice"]),
+        ("Home Phone",    ["home", "voice"]),
+        ("Mobile Number", ["cell"]),
+        ("Fax Number",    ["fax"]),
+        ("Pager Number",  ["pager"]),
+    ]
+
+    def parse_file(self, path: str | Path) -> list[Contact]:
+        # utf-8-sig entfernt BOM falls vorhanden
+        text = Path(path).read_text(encoding="utf-8-sig", errors="replace")
+        reader = csv.DictReader(text.splitlines())
+        contacts = []
+        for row in reader:
+            try:
+                contacts.append(self._parse_row(row))
+            except Exception as e:
+                print(f"Warnung: CSV-Zeile übersprungen: {e}")
+        return contacts
+
+    def _parse_row(self, row: dict) -> Contact:
+        c = Contact()
+
+        for csv_col, attr in self._SIMPLE_FIELDS.items():
+            val = row.get(csv_col, "").strip()
+            if val:
+                setattr(c, attr, val)
+
+        if not c.display_name:
+            c.display_name = c.get_display_name()
+
+        for col, pref in [("Primary Email", True), ("Secondary Email", False)]:
+            addr = row.get(col, "").strip()
+            if addr:
+                c.emails.append(Email(address=addr, types=["internet"], preferred=pref))
+
+        for col, types in self._PHONE_COLS:
+            num = row.get(col, "").strip()
+            if num:
+                c.phones.append(Phone(number=num, types=types, preferred=False))
+
+        home = self._parse_address(row, "Home")
+        if home:
+            home.label = "home"
+            c.addresses.append(home)
+
+        work = self._parse_address(row, "Work")
+        if work:
+            work.label = "work"
+            c.addresses.append(work)
+
+        for col in ("Web Page 1", "Web Page 2"):
+            url = row.get(col, "").strip()
+            if url:
+                c.urls.append(Url(url=url, types=[]))
+
+        bday = self._parse_birthday(row)
+        if bday:
+            c.birthday = bday
+
+        return c
+
+    def _parse_address(self, row: dict, prefix: str) -> Optional[Address]:
+        street = row.get(f"{prefix} Address", "").strip()
+        city   = row.get(f"{prefix} City", "").strip()
+        if not street and not city:
+            return None
+        return Address(
+            street=street,
+            extended=row.get(f"{prefix} Address 2", "").strip(),
+            city=city,
+            region=row.get(f"{prefix} State", "").strip(),
+            postal_code=row.get(f"{prefix} ZipCode", "").strip(),
+            country=row.get(f"{prefix} Country", "").strip(),
+        )
+
+    def _parse_birthday(self, row: dict) -> Optional[date]:
+        try:
+            year  = int(row.get("Birth Year",  "0") or "0")
+            month = int(row.get("Birth Month", "0") or "0")
+            day   = int(row.get("Birth Day",   "0") or "0")
+            if year > 0 and month > 0 and day > 0:
+                return date(year, month, day)
+        except (ValueError, TypeError):
+            pass
+        return None

--- a/adressbuch/storage/database.py
+++ b/adressbuch/storage/database.py
@@ -16,6 +16,7 @@ class Database:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(self.db_path))
         self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
         self._create_tables()
 
     def _create_tables(self):
@@ -59,6 +60,17 @@ class Database:
                 ON contacts(family_name);
             CREATE INDEX IF NOT EXISTS idx_contacts_organization
                 ON contacts(organization);
+
+            CREATE TABLE IF NOT EXISTS groups (
+                id   INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE
+            );
+
+            CREATE TABLE IF NOT EXISTS contact_groups (
+                contact_uid TEXT    NOT NULL REFERENCES contacts(uid) ON DELETE CASCADE,
+                group_id    INTEGER NOT NULL REFERENCES groups(id)    ON DELETE CASCADE,
+                PRIMARY KEY (contact_uid, group_id)
+            );
         """)
         self._conn.commit()
 
@@ -265,6 +277,44 @@ class Database:
 
     def count(self) -> int:
         return self._conn.execute("SELECT COUNT(*) FROM contacts").fetchone()[0]
+
+    # --- Gruppen ---
+
+    def create_group(self, name: str) -> int:
+        """Gruppe anlegen (oder bestehende zurückgeben)."""
+        self._conn.execute(
+            "INSERT OR IGNORE INTO groups (name) VALUES (?)", (name,)
+        )
+        self._conn.commit()
+        row = self._conn.execute(
+            "SELECT id FROM groups WHERE name=?", (name,)
+        ).fetchone()
+        return row["id"]
+
+    def get_all_groups(self) -> list[tuple[int, str]]:
+        """Alle Gruppen als Liste von (id, name)-Tupeln."""
+        rows = self._conn.execute(
+            "SELECT id, name FROM groups ORDER BY name"
+        ).fetchall()
+        return [(r["id"], r["name"]) for r in rows]
+
+    def add_contact_to_group(self, contact_uid: str, group_id: int):
+        """Kontakt einer Gruppe zuordnen (idempotent)."""
+        self._conn.execute(
+            "INSERT OR IGNORE INTO contact_groups (contact_uid, group_id) VALUES (?, ?)",
+            (contact_uid, group_id)
+        )
+        self._conn.commit()
+
+    def get_contacts_in_group(self, group_id: int) -> list[Contact]:
+        """Alle Kontakte einer Gruppe sortiert nach Nachname, Vorname."""
+        rows = self._conn.execute("""
+            SELECT c.* FROM contacts c
+            JOIN contact_groups cg ON cg.contact_uid = c.uid
+            WHERE cg.group_id = ?
+            ORDER BY c.family_name, c.given_name
+        """, (group_id,)).fetchall()
+        return [self._row_to_contact(r) for r in rows]
 
     def close(self):
         self._conn.close()

--- a/adressbuch/storage/settings.py
+++ b/adressbuch/storage/settings.py
@@ -1,0 +1,36 @@
+"""App-Einstellungen (JSON-Datei neben der Datenbank)."""
+
+import json
+from pathlib import Path
+
+
+class Settings:
+    """Persistente App-Einstellungen."""
+
+    _DEFAULTS = {
+        "groups_enabled": False,
+    }
+
+    def __init__(self, path: str | Path):
+        self._path = Path(path)
+        self._data: dict = dict(self._DEFAULTS)
+        if self._path.exists():
+            try:
+                self._data.update(json.loads(self._path.read_text(encoding="utf-8")))
+            except Exception:
+                pass
+
+    def _save(self):
+        self._path.write_text(
+            json.dumps(self._data, indent=2, ensure_ascii=False),
+            encoding="utf-8"
+        )
+
+    @property
+    def groups_enabled(self) -> bool:
+        return bool(self._data.get("groups_enabled", False))
+
+    @groups_enabled.setter
+    def groups_enabled(self, value: bool):
+        self._data["groups_enabled"] = value
+        self._save()


### PR DESCRIPTION
## Zusammenfassung

- **Thunderbird-CSV-Import**: Adressbuch in Thunderbird als CSV exportieren, dann direkt importieren
- **Kontakt-Picker**: Vorschau-Dialog zeigt alle gefundenen Kontakte mit Checkboxen – nur gewünschte auswählen
- **Optionale Gruppenverwaltung**: Beim Import optional einen Gruppennamen vergeben; Gruppen werden automatisch aktiviert wenn genutzt
- **Extras-Menü**: Gruppen manuell aktivieren/deaktivieren unter Extras → Gruppen aktivieren

## Technisches

-  in  parst alle Thunderbird-CSV-Felder
-  in  mit ttk.Treeview + Checkbox-Spalte
- SQLite-Schema um 197121 und  (m:n) erweitert
- -Klasse in  für persistente App-Einstellungen (JSON)

## Test-Checkliste

- [ ] CSV aus Thunderbird importieren (alle Kontakte)
- [ ] Einzelne Kontakte abwählen, nur Auswahl importieren
- [ ] Import mit Gruppenname → Gruppe wird angelegt, Gruppen-Flag aktiviert
- [ ] Import ohne Gruppenname → flacher Pool, kein Fehler
- [ ] Extras → Gruppen aktivieren/deaktivieren → Einstellung bleibt nach Neustart

🤖 Generated with [Claude Code](https://claude.com/claude-code)